### PR TITLE
docs(conf): clarify parameter

### DIFF
--- a/content/docs/conf-bit-json.md
+++ b/content/docs/conf-bit-json.md
@@ -156,5 +156,5 @@ The extension's configuration and options are listed for each extension.
 
 The `resolveModules` section configures custom module resolution for Bit components. This is similar to Webpack's `resolve`, and contains 2 objects:
 
-* `moduleDirectories` - Add additional paths to resolve components from.
+* `moduleDirectories: array` - Add additional paths to resolve components from.
 * `aliases` - Sets an alias for a directory.


### PR DESCRIPTION
Might be helpful - generally I'd add this to all similar parameters, but I think this is a start. :)